### PR TITLE
Skip call to deleteStacks when list of stackIds is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,13 @@ class ServerlessStackSetManager implements Plugin {
       this.serverless.cli.log(`Removing stacks prefixed with: ${config.childStacksNamePrefix}`);
 
       const stackIds = await this.listMatchingStacks(config.childStacksNamePrefix);
-      this.serverless.cli.log(`Found ${stackIds.length} stacks, starting delete operation`);
+      this.serverless.cli.log(`Found ${stackIds.length} stacks`);
 
-      await this.deleteStacks(stackIds, config.maxConcurrentCount);
+      if (stackIds.length > 0) {
+        this.serverless.cli.log('Starting delete operation');
+        await this.deleteStacks(stackIds, config.maxConcurrentCount);
+      }
+
       this.serverless.cli.log('Stacks removed successfully');
     } else {
       this.serverless.cli.log('Skipping remove of child stacks because of removalPolicy setting');


### PR DESCRIPTION
If the ```listMatchingStacks``` yields no stackIds then ```deleteStacks``` is still invoked. Eventually it will get stuck on the call to Promise.race due to the empty iterable. 

MDN [mentions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race#Description) the following when empty iterables are passed to Promise.race:
> If the iterable passed is empty, the promise returned will be forever 

Suggested fix is to skip ```deleteStacks``` when no stacks are to be deleted.