### PR TITLE
Use Travis build status image from master build in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ This can be useful to manage tenant resources in multi-tenant apps, when each te
 
 This repo contains work in progress, do not use.
 
-[icon-ci]: https://img.shields.io/travis/com/coyoteecd/serverless-child-stack-manager.svg?longCache=true&style=flat-square
+[icon-ci]: https://travis-ci.com/coyoteecd/serverless-child-stack-manager.svg?branch=master
 [link-ci]: https://travis-ci.com/coyoteecd/serverless-child-stack-manager


### PR DESCRIPTION
Current Travis build status icon is showing the status of the latest build, regardless of branch.
Should be changed to master build status. 

Note that the link to the travis.ci site does not have the branch name cause Travis does not support landing pages per branch, see https://github.com/travis-ci/travis-ci/issues/5024